### PR TITLE
Same named local labels in different functions no longer cause a redefinition error

### DIFF
--- a/build_tagha_testapp.bat
+++ b/build_tagha_testapp.bat
@@ -1,9 +1,11 @@
+@echo off
+
 set CC=clang
 set CFLAGS=-Wextra -Wall -std=c99 -s -O2
 
 %CC% %CFLAGS% -c libharbol/stringobj.c libharbol/vector.c libharbol/hashmap.c libharbol/mempool.c libharbol/linkmap.c tagha_api.c
 
-ar cr libtagha.a stringobj.o vector.o hashmap.o mempool.o linkmap.o tagha_api.o
+llvm-ar cr libtagha.a stringobj.o vector.o hashmap.o mempool.o linkmap.o tagha_api.o
 
 %CC% %CFLAGS% test_hostapp.c -L. -llibtagha -o taghavmgcc_hosttest.exe
 

--- a/tagha_api.c
+++ b/tagha_api.c
@@ -158,10 +158,14 @@ TAGHA_EXPORT struct TaghaModule *tagha_module_new_from_file(const char filename[
 {
 	if( !filename )
 		return NULL;
+	if( strcmp(filename+strlen(filename)-4, ".tbc") ) {
+		fprintf(stderr, "Tagha module from file Error :: *** file needs to be a .tbc ***\n");
+		return NULL;
+	}
 	
 	uint8_t *restrict bytecode = _make_buffer_from_file(filename);
 	if( !bytecode ) {
-		fprintf(stderr, "tagha module from file Error :: **** failed to create file data buffer. ****\n");
+		fprintf(stderr, "Tagha module from file Error :: **** failed to create file data buffer. ****\n");
 		return NULL;
 	} else if( *(uint16_t *)bytecode != 0xC0DE ) {
 		fprintf(stderr, "Tagha Module Error :: **** invalid tagha module: '%s' ****\n", filename);

--- a/tagha_assembler/tagha_assembler.c
+++ b/tagha_assembler/tagha_assembler.c
@@ -798,8 +798,6 @@ bool tagha_asm_assemble(struct TaghaAsmbler *const restrict tasm)
 				if( !is_alphabetic(tasm->Lexeme->CStr[1]) ) {
 					tagha_asm_err_out(tasm, "%s labels must have alphabetic names!", funclbl ? "function" : "jump");
 				}
-				// Prevents redefinition of local labels because they have the function appended to them
-				printf("Processing '%s'\n", tasm->Lexeme->CStr);
 				if( harbol_linkmap_has_key(funclbl ? tasm->FuncTable : tasm->LabelTable, tasm->Lexeme->CStr) ) {
 					tagha_asm_err_out(tasm, "redefinition of label '%s'.", tasm->Lexeme->CStr);
 				}

--- a/tagha_assembler/tagha_assembler.h
+++ b/tagha_assembler/tagha_assembler.h
@@ -8,7 +8,7 @@ extern "C" {
 #include "../libharbol/harbol.h"
 #include "../tagha.h"
 
-//#define TASM_DEBUG
+#define TASM_DEBUG
 
 struct LabelInfo {
 	struct HarbolByteBuffer Bytecode;


### PR DESCRIPTION
Made some misc changes too, most notably not being able to run non .tbc files, you may remove that if you want
Solves issue #42